### PR TITLE
Parameterized Service Context

### DIFF
--- a/src/ServiceFabric.Mocks/MockActorServiceFactory.cs
+++ b/src/ServiceFabric.Mocks/MockActorServiceFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Fabric;
 using Microsoft.ServiceFabric.Actors;
 using Microsoft.ServiceFabric.Actors.Runtime;
 
@@ -11,11 +12,12 @@ namespace ServiceFabric.Mocks
         /// which returns instances of <see cref="TActor"/> using the optionally provided <paramref name="actorFactory"/>, <paramref name="actorStateProvider"/> and <paramref name="settings"/>.
         /// </summary>
         /// <typeparam name="TActor"></typeparam>
-        /// <param name="settings">Optional settings. By default, null is used.</param>
         /// <param name="actorFactory">Optional Actor factory. By default, null is used.</param>
         /// <param name="actorStateProvider">Optional Actor State Provider. By default, <see cref="MockActorStateProvider"/> is used.</param>
+        /// <param name="context">Optional Actor ServiceContext. By default, <see cref="MockStatefulServiceContextFactory.Default"/> is used.</param>
+        /// <param name="settings">Optional settings. By default, null is used.</param>
         /// <returns></returns>
-        public static MockActorService<TActor> CreateActorServiceForActor<TActor>(Func<ActorService, ActorId, ActorBase> actorFactory = null, IActorStateProvider actorStateProvider = null, ActorServiceSettings settings = null)
+        public static MockActorService<TActor> CreateActorServiceForActor<TActor>(Func<ActorService, ActorId, ActorBase> actorFactory = null, IActorStateProvider actorStateProvider = null, StatefulServiceContext context = null, ActorServiceSettings settings = null)
             where TActor : Actor
         {
             var stateManager = new MockActorStateManager();
@@ -25,7 +27,9 @@ namespace ServiceFabric.Mocks
                 actorStateProvider = new MockActorStateProvider();
                 actorStateProvider.Initialize(ActorTypeInformation.Get(typeof(TActor)));
             }
-            var svc = new MockActorService<TActor>(MockStatefulServiceContextFactory.Default, ActorTypeInformation.Get(typeof(TActor)), actorFactory, stateManagerFactory, actorStateProvider, settings);
+
+            context = context ?? MockStatefulServiceContextFactory.Default;
+            var svc = new MockActorService<TActor>(context, ActorTypeInformation.Get(typeof(TActor)), actorFactory, stateManagerFactory, actorStateProvider, settings);
             return svc;
         }
     }

--- a/src/ServiceFabric.Mocks/MockStatefulServiceContext.cs
+++ b/src/ServiceFabric.Mocks/MockStatefulServiceContext.cs
@@ -18,6 +18,24 @@ namespace ServiceFabric.Mocks
            null,
            Guid.NewGuid(),
            long.MaxValue
-       );
+        );
+
+        /// <summary>
+        /// Returns an instance of <see cref="StatefulServiceContext"/> using <see cref="MockCodePackageActivationContext.Default"/>
+        /// and the specified Service URI
+        /// </summary>
+        /// <param name="serviceUri">The URI that should be used by the ServiceContext</param>
+        /// <returns>The constructed <see cref="StatefulServiceContext"/></returns>
+        public static StatefulServiceContext WithCustomUri(Uri serviceUri)
+        {
+            return new StatefulServiceContext(
+               new NodeContext("Node0", new NodeId(0, 1), 0, "NodeType1", "MOCK.MACHINE"),
+               MockCodePackageActivationContext.Default, "MockServiceType",
+               serviceUri,
+               null,
+               Guid.NewGuid(),
+               long.MaxValue
+            );
+        }
     }
 }


### PR DESCRIPTION
- Added support for being able to supply service contexts with alternate URIs