### PR TITLE
refactored MockActorProxyFactory to allow multiple actors with different types to have the same ActorId

### DIFF
--- a/src/ServiceFabric.Mocks/MockActorProxyFactory.cs
+++ b/src/ServiceFabric.Mocks/MockActorProxyFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using Microsoft.ServiceFabric.Actors;
 using Microsoft.ServiceFabric.Actors.Client;
 using Microsoft.ServiceFabric.Services.Remoting;
@@ -11,7 +12,7 @@ namespace ServiceFabric.Mocks
     /// </summary>
     public class MockActorProxyFactory : MockServiceProxyFactory, IActorProxyFactory
     {
-        private readonly ConcurrentDictionary<ActorId, IActor> _actorRegistry = new ConcurrentDictionary<ActorId, IActor>();
+        readonly ConcurrentDictionary<ActorId, ConcurrentBag<IActor>> _actorRegistry = new ConcurrentDictionary<ActorId, ConcurrentBag<IActor>>();
 
         /// <summary>
         /// Registers an instance of a Actor combined with its Id to be able to return it from 
@@ -20,23 +21,35 @@ namespace ServiceFabric.Mocks
         /// <param name="actor"></param>
         public void RegisterActor(IActor actor)
         {
-            _actorRegistry.AddOrUpdate(actor.GetActorId(), actor, (name, svc) => actor);
+            _actorRegistry.AddOrUpdate(
+                actor.GetActorId(),
+                id => new ConcurrentBag<IActor>(new [] { actor }),
+                (id, bag) =>
+                {
+                    if (bag.Any(a => a.GetType() == actor.GetType()))
+                    {
+                        throw new ArgumentException($"There is already an actor of type {actor.GetType()} with the actorId {id}.");
+                    }
+
+                    bag.Add(actor);
+                    return bag;
+                });
         }
 
         ///<inheritdoc />
         public TActorInterface CreateActorProxy<TActorInterface>(ActorId actorId, string applicationName = null,
             string serviceName = null, string listenerName = null) where TActorInterface : IActor
         {
-            var actor = _actorRegistry[actorId];
-            return (TActorInterface)actor;
+            var bag = _actorRegistry[actorId];
+            return bag.OfType<TActorInterface>().SingleOrDefault();
         }
 
         ///<inheritdoc />
         public TActorInterface CreateActorProxy<TActorInterface>(Uri serviceUri, ActorId actorId, string listenerName = null) 
             where TActorInterface : IActor
         {
-            var actor = _actorRegistry[actorId];
-            return (TActorInterface)actor;
+            var bag = _actorRegistry[actorId];
+            return bag.OfType<TActorInterface>().SingleOrDefault();
         }
 
         ///<inheritdoc />

--- a/test/ServiceFabric.Mocks.Tests/MocksTests/MockActorServiceFactoryTests.cs
+++ b/test/ServiceFabric.Mocks.Tests/MocksTests/MockActorServiceFactoryTests.cs
@@ -37,7 +37,6 @@ namespace ServiceFabric.Mocks.Tests.MocksTests
 			Assert.AreEqual(serviceContext, instance.Context);
 		}
 
-
 		// ReSharper disable once ClassNeverInstantiated.Local   //implicit
 		private class MockActor : Actor, IMockActor
 		{


### PR DESCRIPTION
Fixes #5 by changing the `ConcurrentDictionary` to store collections of actors instead of a single actor.