### PR TITLE
Allow MockActorServiceFactory to create several actors

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Or [donate](https://paypal.me/lduys/5) a cup of coffee.
 
 ## Release notes
 
+- 2.2.1
+	- Allow MockActorServiceFactory to create several actors
+
 - 2.2.0
 	- Upgraded nuget packages (SF 2.6.220, MSTest 1.1.18)
 

--- a/src/ServiceFabric.Mocks/MockActorServiceFactory.cs
+++ b/src/ServiceFabric.Mocks/MockActorServiceFactory.cs
@@ -20,8 +20,7 @@ namespace ServiceFabric.Mocks
         public static MockActorService<TActor> CreateActorServiceForActor<TActor>(Func<ActorService, ActorId, ActorBase> actorFactory = null, IActorStateProvider actorStateProvider = null, StatefulServiceContext context = null, ActorServiceSettings settings = null)
             where TActor : Actor
         {
-            var stateManager = new MockActorStateManager();
-            Func<ActorBase, IActorStateProvider, IActorStateManager> stateManagerFactory = (actr, stateProvider) => stateManager;
+            Func<ActorBase, IActorStateProvider, IActorStateManager> stateManagerFactory = (actr, stateProvider) => new MockActorStateManager();
             if (actorStateProvider == null)
             {
                 actorStateProvider = new MockActorStateProvider();

--- a/test/ServiceFabric.Mocks.Tests/ActorTests/MyStatefulActorTests.cs
+++ b/test/ServiceFabric.Mocks.Tests/ActorTests/MyStatefulActorTests.cs
@@ -11,6 +11,7 @@ namespace ServiceFabric.Mocks.Tests.ActorTests
     public class MyStatefulActorTests
     {
         private const string StatePayload = "some value";
+        private const string OtherStatePayload = "some other value";
 
         [TestMethod]
         public async Task TestActorState()
@@ -29,9 +30,35 @@ namespace ServiceFabric.Mocks.Tests.ActorTests
             Assert.AreEqual(StatePayload, actual.Content);
         }
 
+        [TestMethod]
+        public async Task TestMultipleActors()
+        {
+            Func<ActorService, ActorId, ActorBase> actorFactory = (service, actorId) => new MyStatefulActor(service, actorId);
+            var svc = MockActorServiceFactory.CreateActorServiceForActor<MyStatefulActor>(actorFactory);
+            var actor1 = svc.Activate(new ActorId(Guid.NewGuid()));
+            var actor2 = svc.Activate(new ActorId(Guid.NewGuid()));
+
+            var stateManager1 = (MockActorStateManager)actor1.StateManager;
+            var stateManager2 = (MockActorStateManager)actor2.StateManager;
+
+            const string stateName = "test";
+            var payload1 = new Payload(StatePayload);
+            var payload2 = new Payload(OtherStatePayload);
+
+            //create states
+            await actor1.InsertAsync(stateName, payload1);
+            await actor2.InsertAsync(stateName, payload2);
+
+            //get states
+            var actual1 = await stateManager1.GetStateAsync<Payload>(stateName);
+            Assert.AreEqual(StatePayload, actual1.Content);
+            var actual2 = await stateManager2.GetStateAsync<Payload>(stateName);
+            Assert.AreEqual(OtherStatePayload, actual2.Content);
+        }
+
         private static MyStatefulActor CreateActor(ActorId id)
         {
-            Func<ActorService, ActorId, ActorBase> actorFactory = (service, actorId) => new MyStatefulActor(service, id);
+            Func<ActorService, ActorId, ActorBase> actorFactory = (service, actorId) => new MyStatefulActor(service, actorId);
             var svc = MockActorServiceFactory.CreateActorServiceForActor<MyStatefulActor>(actorFactory);
             var actor = svc.Activate(id);
             return actor;


### PR DESCRIPTION
As per [Actors Documentation](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-reliable-actors-state-management) :
"Every actor instance has its own state manager", so let's be compliant with
that by default.