### PR TITLE
Minimal changes to accomodate the new Service Fabric 2.8 SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Or [donate](https://paypal.me/lduys/5) a cup of coffee.
 
 ## Release notes
 
+- 2.3.0
+	- Merged PR by dotnetgator, upgrading to SF 2.8.211
+
 - 2.2.4
 	- Added `InvokeOnPreActorMethodAsync` & `InvokeOnPostActorMethodAsync` on `ActorBaseExtensions`, requested by JefSchraag.
 

--- a/src/ServiceFabric.Mocks/MockActorStateProvider.cs
+++ b/src/ServiceFabric.Mocks/MockActorStateProvider.cs
@@ -75,7 +75,7 @@ namespace ServiceFabric.Mocks
 
         public Func<CancellationToken, Task<bool>> OnDataLossAsync { get; set; }
 
-        
+        public Func<CancellationToken, Task> OnRestoreCompletedAsync { get; set; }
 
         public Task ActorActivatedAsync(ActorId actorId, CancellationToken cancellationToken = new CancellationToken())
         {

--- a/src/ServiceFabric.Mocks/MockReliableStateManager.cs
+++ b/src/ServiceFabric.Mocks/MockReliableStateManager.cs
@@ -16,7 +16,7 @@ namespace ServiceFabric.Mocks
     /// <summary>
     /// Defines replica of a reliable state provider.
     /// </summary>
-    public class MockReliableStateManager : IReliableStateManagerReplica
+    public class MockReliableStateManager : IReliableStateManagerReplica2
     {
         private ConcurrentDictionary<Uri, IReliableState> _store = new ConcurrentDictionary<Uri, IReliableState>();
 
@@ -40,6 +40,11 @@ namespace ServiceFabric.Mocks
         /// Called when <see cref="TriggerDataLoss"/> is called.
         /// </summary>
         public Func<CancellationToken, Task<bool>> OnDataLossAsync { set; get; }
+
+        /// <summary>
+        /// Called when <see cref="TriggerRestoreCompleted"/> is called.
+        /// </summary>
+        public Func<CancellationToken, Task> OnRestoreCompletedAsync { get; set; }
 
         public void Abort()
         {
@@ -272,6 +277,11 @@ namespace ServiceFabric.Mocks
         public Task TriggerDataLoss()
         {
             return OnDataLossAsync(CancellationToken.None);
+        }
+
+        public Task TriggerRestoreCompleted()
+        {
+            return OnRestoreCompletedAsync(CancellationToken.None);
         }
 
         private static Uri CreateUri(string name)

--- a/src/ServiceFabric.Mocks/MockServiceProxy.cs
+++ b/src/ServiceFabric.Mocks/MockServiceProxy.cs
@@ -19,7 +19,9 @@ namespace ServiceFabric.Mocks
 
         public Type ServiceInterfaceType => typeof(TService);
 
-        public IServiceRemotingPartitionClient ServicePartitionClient { get { throw new NotImplementedException(); } }
+        public Microsoft.ServiceFabric.Services.Remoting.V1.Client.IServiceRemotingPartitionClient ServicePartitionClient { get { throw new NotImplementedException(); } }
+
+        public Microsoft.ServiceFabric.Services.Remoting.V2.Client.IServiceRemotingPartitionClient ServicePartitionClient2 { get { throw new NotImplementedException(); } }
 
         public TService Create(Type serviceType, Uri serviceUri, ServicePartitionKey partitionKey = null, TargetReplicaSelector targetReplicaSelector = TargetReplicaSelector.Default, string listenerName = null)
         {

--- a/src/ServiceFabric.Mocks/MockServiceRemotingClientFactory.cs
+++ b/src/ServiceFabric.Mocks/MockServiceRemotingClientFactory.cs
@@ -6,8 +6,8 @@ using System.Threading.Tasks;
 using Microsoft.ServiceFabric.Actors.Runtime;
 using Microsoft.ServiceFabric.Services.Client;
 using Microsoft.ServiceFabric.Services.Communication.Client;
-using Microsoft.ServiceFabric.Services.Remoting;
-using Microsoft.ServiceFabric.Services.Remoting.Client;
+using Microsoft.ServiceFabric.Services.Remoting.V1;
+using Microsoft.ServiceFabric.Services.Remoting.V1.Client;
 
 namespace ServiceFabric.Mocks
 {
@@ -182,5 +182,5 @@ namespace ServiceFabric.Mocks
 		public void SendOneWay(ServiceRemotingMessageHeaders messageHeaders, byte[] requestBody)
 		{
 		}
-	}
+    }
 }

--- a/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
+++ b/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
@@ -4,7 +4,7 @@
     <Description>ServiceFabric.Mocks contains many Mock and helper classes to facilitate and simplify unit testing of Service Fabric Actors and Services.</Description>
     <Copyright>2017</Copyright>
     <AssemblyTitle>ServiceFabric.Mocks</AssemblyTitle>
-    <VersionPrefix>2.2.5</VersionPrefix>
+    <VersionPrefix>2.3.0</VersionPrefix>
     <Authors>Loek Duys</Authors>
     <TargetFrameworks>net451;net46</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>

--- a/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
+++ b/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
@@ -31,8 +31,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="2.7.198" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="2.7.198" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="2.8.211" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="2.8.211" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/test/ServiceFabric.Mocks.Tests/ServiceFabric.Mocks.Tests.csproj
+++ b/test/ServiceFabric.Mocks.Tests/ServiceFabric.Mocks.Tests.csproj
@@ -45,8 +45,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="2.7.198" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="2.7.198" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="2.8.211" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="2.8.211" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/test/ServiceFabric.Mocks.Tests/ServiceFabric.Mocks.Tests.csproj
+++ b/test/ServiceFabric.Mocks.Tests/ServiceFabric.Mocks.Tests.csproj
@@ -8,7 +8,7 @@
     <Description>ServiceFabric.Mocks contains Mock classes to enable unit testing of Actors and Services</Description>
     <Copyright>2017</Copyright>
     <AssemblyTitle>ServiceFabric.Mocks.Tests</AssemblyTitle>
-    <VersionPrefix>2.2.5</VersionPrefix>
+    <VersionPrefix>2.3.0</VersionPrefix>
     <Authors>Loek Duys</Authors>
     <TargetFrameworks>net451;net46</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>

--- a/test/ServiceFabric.Mocks.Tests/ServiceRemoting/ServiceRemotingTests.cs
+++ b/test/ServiceFabric.Mocks.Tests/ServiceRemoting/ServiceRemotingTests.cs
@@ -10,7 +10,7 @@ using Microsoft.ServiceFabric.Data;
 using Microsoft.ServiceFabric.Services.Client;
 using Microsoft.ServiceFabric.Services.Communication.Client;
 using Microsoft.ServiceFabric.Services.Remoting;
-using Microsoft.ServiceFabric.Services.Remoting.Client;
+using Microsoft.ServiceFabric.Services.Remoting.V1.Client;
 using Microsoft.ServiceFabric.Services.Runtime;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ServiceFabric.Mocks.Tests.Actors;
@@ -96,7 +96,7 @@ namespace ServiceFabric.Mocks.Tests.ServiceRemoting
 				_subscriptionHelper = subscriptionHelper ?? new ActorEventSubscriptionHelper();
 			}
 
-			public ExampleClient(StatefulServiceContext serviceContext, IReliableStateManagerReplica reliableStateManagerReplica,
+			public ExampleClient(StatefulServiceContext serviceContext, IReliableStateManagerReplica2 reliableStateManagerReplica,
 				IActorEventSubscriptionHelper subscriptionHelper, IActorProxyFactory actorProxyFactory)
 				: base(serviceContext, reliableStateManagerReplica)
 			{

--- a/test/ServiceFabric.Mocks.Tests/Services/MyStatefulService.cs
+++ b/test/ServiceFabric.Mocks.Tests/Services/MyStatefulService.cs
@@ -17,7 +17,7 @@ namespace ServiceFabric.Mocks.Tests.Services
         {
         }
 
-        public MyStatefulService(StatefulServiceContext serviceContext, IReliableStateManagerReplica reliableStateManagerReplica)
+        public MyStatefulService(StatefulServiceContext serviceContext, IReliableStateManagerReplica2 reliableStateManagerReplica)
             : base(serviceContext, reliableStateManagerReplica)
         {
         }


### PR DESCRIPTION
Minimal changes to accommodate the new interface and namespace updates in the 2.8 SDK - focused on working with V1 namespace; no direct work done to accomodate the new V2 yet.  The focus here is so that projects that rely on this and are merely upgrading to the 2.8 SDK without adopting the new V2 communication/serialization content can do so.