### PR TITLE
Add Spy Properties to MockReliableStateManager and MockTransaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Or [donate](https://paypal.me/lduys/5) a cup of coffee.
 
 ## Release notes
 
+- 2.3.1
+	- Merged PR by Izzmo, adding a list of past Transactions to the `MockReliableStateManager`. Added unit tests
+
 - 2.3.0
 	- Merged PR by dotnetgator, upgrading to SF 2.8.211
 

--- a/src/ServiceFabric.Mocks/MockReliableStateManager.cs
+++ b/src/ServiceFabric.Mocks/MockReliableStateManager.cs
@@ -20,6 +20,14 @@ namespace ServiceFabric.Mocks
     {
         private ConcurrentDictionary<Uri, IReliableState> _store = new ConcurrentDictionary<Uri, IReliableState>();
 
+        public MockTransaction Transaction { get; private set; }
+
+        public bool TransanctionIsCreated => Transaction != null;
+
+        public bool TransactionIsCommitted => Transaction != null && Transaction.IsCommitted;
+
+        public bool TransactionIsAborted => Transaction != null && Transaction.IsAborted;
+
         /// <summary>
         /// Returns last known <see cref="ReplicaRole"/>.
         /// </summary>
@@ -91,7 +99,12 @@ namespace ServiceFabric.Mocks
 
         public ITransaction CreateTransaction()
         {
-            return new MockTransaction();
+            if (Transaction != null && !Transaction.IsCompleted)
+                throw new InvalidOperationException("Only one transaction is currently supported.");
+
+            Transaction = new MockTransaction();
+
+            return Transaction;
         }
 
         public IAsyncEnumerator<IReliableState> GetAsyncEnumerator()

--- a/src/ServiceFabric.Mocks/MockTransaction.cs
+++ b/src/ServiceFabric.Mocks/MockTransaction.cs
@@ -31,7 +31,6 @@ namespace ServiceFabric.Mocks
 
         public void Dispose()
         {
-            Dispose();
             IsAborted = true;
         }
 

--- a/src/ServiceFabric.Mocks/MockTransaction.cs
+++ b/src/ServiceFabric.Mocks/MockTransaction.cs
@@ -4,25 +4,35 @@ using Microsoft.ServiceFabric.Data;
 namespace ServiceFabric.Mocks
 {  
     /// <summary>
-   /// A sequence of operations performed as a single logical unit of work.
-   /// </summary>
+    /// A sequence of operations performed as a single logical unit of work.
+    /// </summary>
     public class MockTransaction : ITransaction
     {
         public long CommitSequenceNumber => 0L;
+
+        public bool IsCommitted { get; private set; }
+
+        public bool IsAborted { get; private set; }
+
+        public bool IsCompleted => IsCommitted || IsAborted;
 
         public long TransactionId => 0L;
 
         public void Abort()
         {
+            IsAborted = true;
         }
 
         public Task CommitAsync()
         {
+            IsCommitted = true;
             return Task.FromResult(true);
         }
 
         public void Dispose()
         {
+            Dispose();
+            IsAborted = true;
         }
 
         public Task<long> GetVisibilitySequenceNumberAsync()

--- a/src/ServiceFabric.Mocks/MockTransaction.cs
+++ b/src/ServiceFabric.Mocks/MockTransaction.cs
@@ -8,6 +8,8 @@ namespace ServiceFabric.Mocks
     /// </summary>
     public class MockTransaction : ITransaction
     {
+        public int InstanceCount { get; }
+
         public long CommitSequenceNumber => 0L;
 
         public bool IsCommitted { get; private set; }
@@ -18,20 +20,34 @@ namespace ServiceFabric.Mocks
 
         public long TransactionId => 0L;
 
+        public MockTransaction(int instanceCount)
+        {
+            InstanceCount = instanceCount;
+        }
+
         public void Abort()
         {
-            IsAborted = true;
+            if (!IsCommitted)
+            {
+                IsAborted = true;
+            }
         }
 
         public Task CommitAsync()
         {
-            IsCommitted = true;
+            if (!IsAborted)
+            {
+                IsCommitted = true;
+            }
             return Task.FromResult(true);
         }
 
         public void Dispose()
         {
-            IsAborted = true;
+            if (!IsCommitted)
+            {
+                IsAborted = true;
+            }
         }
 
         public Task<long> GetVisibilitySequenceNumberAsync()

--- a/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
+++ b/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
@@ -4,7 +4,7 @@
     <Description>ServiceFabric.Mocks contains many Mock and helper classes to facilitate and simplify unit testing of Service Fabric Actors and Services.</Description>
     <Copyright>2017</Copyright>
     <AssemblyTitle>ServiceFabric.Mocks</AssemblyTitle>
-    <VersionPrefix>2.3.0</VersionPrefix>
+    <VersionPrefix>2.3.1</VersionPrefix>
     <Authors>Loek Duys</Authors>
     <TargetFrameworks>net451;net46</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>

--- a/test/ServiceFabric.Mocks.Tests/ActorTests/ServiceCallerActorTests.cs
+++ b/test/ServiceFabric.Mocks.Tests/ActorTests/ServiceCallerActorTests.cs
@@ -50,6 +50,11 @@ namespace ServiceFabric.Mocks.Tests.ActorTests
                 InsertAsyncCalled = true;
                 return Task.FromResult(true);
             }
+
+            public Task InsertAndAbortAsync(string stateName, Payload value)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/test/ServiceFabric.Mocks.Tests/ServiceFabric.Mocks.Tests.csproj
+++ b/test/ServiceFabric.Mocks.Tests/ServiceFabric.Mocks.Tests.csproj
@@ -8,7 +8,7 @@
     <Description>ServiceFabric.Mocks contains Mock classes to enable unit testing of Actors and Services</Description>
     <Copyright>2017</Copyright>
     <AssemblyTitle>ServiceFabric.Mocks.Tests</AssemblyTitle>
-    <VersionPrefix>2.3.0</VersionPrefix>
+    <VersionPrefix>2.3.1</VersionPrefix>
     <Authors>Loek Duys</Authors>
     <TargetFrameworks>net451;net46</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>

--- a/test/ServiceFabric.Mocks.Tests/Services/IMyStatefulService.cs
+++ b/test/ServiceFabric.Mocks.Tests/Services/IMyStatefulService.cs
@@ -10,5 +10,7 @@ namespace ServiceFabric.Mocks.Tests.Services
         Task EnqueueAsync(Payload value);
 
         Task InsertAsync(string stateName, Payload value);
+
+        Task InsertAndAbortAsync(string stateName, Payload value);
     }
 }

--- a/test/ServiceFabric.Mocks.Tests/Services/MyStatefulService.cs
+++ b/test/ServiceFabric.Mocks.Tests/Services/MyStatefulService.cs
@@ -33,6 +33,17 @@ namespace ServiceFabric.Mocks.Tests.Services
             }
         }
 
+        public async Task InsertAndAbortAsync(string stateName, Payload value)
+        {
+            var dictionary = await StateManager.GetOrAddAsync<IReliableDictionary<string, Payload>>(StateManagerDictionaryKey);
+
+            using (var tx = StateManager.CreateTransaction())
+            {
+                await dictionary.TryAddAsync(tx, stateName, value);
+                tx.Abort();
+            }
+        }
+
 
         public async Task EnqueueAsync(Payload value)
         {

--- a/test/ServiceFabric.Mocks.Tests/TransactionTests/TransactionTests.cs
+++ b/test/ServiceFabric.Mocks.Tests/TransactionTests/TransactionTests.cs
@@ -1,0 +1,143 @@
+﻿using System.Threading.Tasks;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ServiceFabric.Mocks.Tests.Services;
+using System.Linq;
+
+namespace ServiceFabric.Mocks.Tests.TransactionTests
+{
+    [TestClass]
+    public class TransactionTests
+    {
+        private const string StatePayload = "some value";
+
+        [TestMethod]
+        public async Task TestServiceState_TransactionCommitted()
+        {
+            var context = MockStatefulServiceContextFactory.Default;
+            var stateManager = new MockReliableStateManager();
+            var service = new MyStatefulService(context, stateManager);
+
+            const string stateName = "test";
+            var payload = new Payload(StatePayload);
+
+            //create state-->Tran 1
+            await service.InsertAsync(stateName, payload);
+
+            Assert.IsInstanceOfType(stateManager.Transaction, typeof(MockTransaction));
+            Assert.AreEqual(1, stateManager.AllTransactions.Count());
+            Assert.IsTrue(stateManager.Transaction.IsCommitted);
+            Assert.IsFalse(stateManager.Transaction.IsAborted);
+        }
+
+        [TestMethod]
+        public async Task TestServiceState_TwoTransactionsCommitted()
+        {
+            var context = MockStatefulServiceContextFactory.Default;
+            var stateManager = new MockReliableStateManager();
+            var service = new MyStatefulService(context, stateManager);
+
+            const string stateName = "test";
+            var payload = new Payload(StatePayload);
+
+            //create state-->Tran 1
+            await service.InsertAsync(stateName, payload);
+            //create state-->Tran 2
+            await service.InsertAsync(stateName, payload);
+
+            Assert.IsInstanceOfType(stateManager.Transaction, typeof(MockTransaction));
+            Assert.AreEqual(2, stateManager.AllTransactions.Count());
+            Assert.IsTrue(stateManager.Transaction.IsCommitted);
+            Assert.IsFalse(stateManager.Transaction.IsAborted);
+        }
+
+        [TestMethod]
+        public async Task TestServiceState_100TransactionsCommitted()
+        {
+            var context = MockStatefulServiceContextFactory.Default;
+            var stateManager = new MockReliableStateManager();
+            var service = new MyStatefulService(context, stateManager);
+
+            const string stateName = "test";
+            var payload = new Payload(StatePayload);
+
+            var tasks = new List<Task>(100);
+            for (int i = 0; i < 100; i++)
+            {
+                //create state
+                tasks.Add(service.InsertAsync(stateName, payload));
+            };
+            await Task.WhenAll(tasks);
+            Assert.IsInstanceOfType(stateManager.Transaction, typeof(MockTransaction));
+            Assert.AreEqual(100, stateManager.AllTransactions.Count());
+            Assert.IsTrue(stateManager.Transaction.IsCommitted);
+            Assert.IsFalse(stateManager.Transaction.IsAborted);
+        }
+
+        [TestMethod]
+        public async Task TestServiceState_99TransactionsCommittedOneAborted()
+        {
+            var context = MockStatefulServiceContextFactory.Default;
+            var stateManager = new MockReliableStateManager();
+            var service = new MyStatefulService(context, stateManager);
+
+            const string stateName = "test";
+            var payload = new Payload(StatePayload);
+
+            var tasks = new List<Task>(99);
+            for (int i = 0; i < 99; i++)
+            {
+                //create state
+                tasks.Add(service.InsertAsync(stateName, payload));
+            };
+            await Task.WhenAll(tasks);
+            await service.InsertAndAbortAsync(stateName, payload);
+            Assert.IsInstanceOfType(stateManager.Transaction, typeof(MockTransaction));
+            Assert.AreEqual(100, stateManager.AllTransactions.Count());
+            Assert.IsFalse(stateManager.Transaction.IsCommitted);
+            Assert.IsTrue(stateManager.Transaction.IsAborted);
+            //check ordering
+            Assert.IsTrue(stateManager.AllTransactions.Select(t=>t.InstanceCount).SequenceEqual(Enumerable.Range(1, 100)));
+        }
+
+        [TestMethod]
+        public async Task TestServiceState_TransactionAborted()
+        {
+            var context = MockStatefulServiceContextFactory.Default;
+            var stateManager = new MockReliableStateManager();
+            var service = new MyStatefulService(context, stateManager);
+
+            const string stateName = "test";
+            var payload = new Payload(StatePayload);
+
+            //create state-->Tran 1
+            await service.InsertAndAbortAsync(stateName, payload);
+
+            Assert.IsInstanceOfType(stateManager.Transaction, typeof(MockTransaction));
+            Assert.AreEqual(1, stateManager.AllTransactions.Count());
+            Assert.IsFalse(stateManager.Transaction.IsCommitted);
+            Assert.IsTrue(stateManager.Transaction.IsAborted);
+        }
+
+        [TestMethod]
+        public async Task TestServiceState_TwoTransactionsOneCommitted()
+        {
+            var context = MockStatefulServiceContextFactory.Default;
+            var stateManager = new MockReliableStateManager();
+            var service = new MyStatefulService(context, stateManager);
+
+            const string stateName = "test";
+            var payload = new Payload(StatePayload);
+
+            //create state-->Tran 1
+            await service.InsertAsync(stateName, payload);
+            //create state-->Tran 2
+            await service.InsertAndAbortAsync(stateName, payload);
+
+            Assert.IsInstanceOfType(stateManager.Transaction, typeof(MockTransaction));
+            Assert.AreEqual(2, stateManager.AllTransactions.Count());
+            Assert.IsFalse(stateManager.Transaction.IsCommitted);
+            Assert.IsTrue(stateManager.Transaction.IsAborted);
+        }
+    }
+}


### PR DESCRIPTION
This methods allow for easier transparency so when designing unit tests, especially when working with a `ReliableDictionary<T>`, you can make sure the transaction were committed/used properly.

_Further_: I did not see any unit tests around these two classes.