### PR TITLE
Fixed TryAddState on MockActorStateManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Or [donate](https://paypal.me/lduys/5) a cup of coffee.
 The VSTS Agent lagged behind in Service Fabric SDK version, this caused runtime errors. This issue is now resolved. 
 
 ## Release notes
+- 3.0.1
+	- Merged PR by esbenbach, fix `ActorStateManager` `TryAddStateAsync` behavior not same as actual implementation. Added unit test.
+
 - 3.0.0
 	- Merged PR by ralphcu
 	- Breaking change: list of past Transactions replaced by events (`MockTransactionChanged`)

--- a/src/ServiceFabric.Mocks/MockActorStateManager.cs
+++ b/src/ServiceFabric.Mocks/MockActorStateManager.cs
@@ -94,7 +94,7 @@ namespace ServiceFabric.Mocks
         /// <inheritdoc />
         public Task<bool> TryAddStateAsync<T>(string stateName, T value, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (Task<bool>)AddStateAsync(stateName, value, cancellationToken);
+            return Task.FromResult(_state.TryAdd(stateName, value));
         }
 
         /// <inheritdoc />

--- a/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
+++ b/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
@@ -4,7 +4,7 @@
     <Description>ServiceFabric.Mocks contains many Mock and helper classes to facilitate and simplify unit testing of Service Fabric Actors and Services.</Description>
     <Copyright>2017</Copyright>
     <AssemblyTitle>ServiceFabric.Mocks</AssemblyTitle>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.0.1</VersionPrefix>
     <Authors>Loek Duys</Authors>
     <TargetFrameworks>net451;net46</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>

--- a/test/ServiceFabric.Mocks.Tests/MocksTests/MockActorStateManagerTests.cs
+++ b/test/ServiceFabric.Mocks.Tests/MocksTests/MockActorStateManagerTests.cs
@@ -99,6 +99,16 @@ namespace ServiceFabric.Mocks.Tests.MocksTests
 		}
 
         [TestMethod]
+        public async Task Int_DuplicateTryAddStateAsyncTest()
+        {
+            var instance = new MockActorStateManager();
+            await instance.TryAddStateAsync("existing", 6);
+            var result = await instance.TryAddStateAsync("existing", 6);
+
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
         public async Task MultiType_SetStateAsyncTest()
         {
             var instance = new MockActorStateManager();

--- a/test/ServiceFabric.Mocks.Tests/ServiceFabric.Mocks.Tests.csproj
+++ b/test/ServiceFabric.Mocks.Tests/ServiceFabric.Mocks.Tests.csproj
@@ -8,7 +8,7 @@
     <Description>ServiceFabric.Mocks contains Mock classes to enable unit testing of Actors and Services</Description>
     <Copyright>2017</Copyright>
     <AssemblyTitle>ServiceFabric.Mocks.Tests</AssemblyTitle>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.0.1</VersionPrefix>
     <Authors>Loek Duys</Authors>
     <TargetFrameworks>net451;net46</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>


### PR DESCRIPTION
Changed the behaviour of the TryAddState method of the MockActorStateManager to behave like the actual implementation, i.e. to not throw on second add but just return false.

Added a test to prevent regression.