### PR TITLE
Add IReliableDictionary2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Or [donate](https://paypal.me/lduys/5) a cup of coffee.
 The VSTS Agent lagged behind in Service Fabric SDK version, this caused runtime errors. This issue is now resolved. 
 
 ## Release notes
+ 3.1.2
+	- Add support for `IReliableDictionary2`
+
 - 3.1.1
 	- Sign assembly
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The VSTS Agent lagged behind in Service Fabric SDK version, this caused runtime 
 
 ## Release notes
  3.1.2
-	- Add support for `IReliableDictionary2`
+	- Merged PR by Jaah. Add support for `IReliableDictionary2`
 
 - 3.1.1
 	- Sign assembly

--- a/src/ServiceFabric.Mocks/ReliableCollections/MockReliableDictionary.cs
+++ b/src/ServiceFabric.Mocks/ReliableCollections/MockReliableDictionary.cs
@@ -14,7 +14,7 @@
     /// </summary>
     /// <typeparam name="TKey"></typeparam>
     /// <typeparam name="TValue"></typeparam>
-    public class MockReliableDictionary<TKey, TValue> : TransactedConcurrentDictionary<TKey, TValue>, IReliableDictionary<TKey, TValue>, IReliableDictionary2<TKey, TValue>
+    public class MockReliableDictionary<TKey, TValue> : TransactedConcurrentDictionary<TKey, TValue>, IReliableDictionary2<TKey, TValue>
         where TKey : IEquatable<TKey>, IComparable<TKey>
     {
         public long Count => Dictionary.Count;
@@ -28,7 +28,7 @@
                 {
                     if (DictionaryChanged != null)
                     {
-                        NotifyDictionaryChangedEventArgs<TKey, TValue> e = null;
+                        NotifyDictionaryChangedEventArgs<TKey, TValue> e;
                         switch (c.ChangeType)
                         {
                             case ChangeType.Added:

--- a/src/ServiceFabric.Mocks/ReliableCollections/MockReliableDictionary.cs
+++ b/src/ServiceFabric.Mocks/ReliableCollections/MockReliableDictionary.cs
@@ -14,9 +14,11 @@
     /// </summary>
     /// <typeparam name="TKey"></typeparam>
     /// <typeparam name="TValue"></typeparam>
-    public class MockReliableDictionary<TKey, TValue> : TransactedConcurrentDictionary<TKey, TValue>, IReliableDictionary<TKey, TValue>
+    public class MockReliableDictionary<TKey, TValue> : TransactedConcurrentDictionary<TKey, TValue>, IReliableDictionary<TKey, TValue>, IReliableDictionary2<TKey, TValue>
         where TKey : IEquatable<TKey>, IComparable<TKey>
     {
+        public long Count => Dictionary.Count;
+
         public MockReliableDictionary(Uri uri)
             : base(uri, null)
         {
@@ -52,6 +54,8 @@
         }
 
         public Func<IReliableDictionary<TKey, TValue>, NotifyDictionaryRebuildEventArgs<TKey, TValue>, Task> RebuildNotificationAsyncCallback { set => throw new NotImplementedException(); }
+
+
 
         public event EventHandler<NotifyDictionaryChangedEventArgs<TKey, TValue>> DictionaryChanged;
         public event EventHandler<DictionaryChange> MockDictionaryChanged;
@@ -138,6 +142,51 @@
                 }
 
                 IAsyncEnumerable<KeyValuePair<TKey, TValue>> result = new MockAsyncEnumerable<KeyValuePair<TKey, TValue>>(keys.Select(k => new KeyValuePair<TKey, TValue>(k, Dictionary[k])));
+                return result;
+            }
+            catch
+            {
+                foreach (var key in keys)
+                {
+                    LockManager.ReleaseLock(tx.TransactionId, key);
+                }
+
+                throw;
+            }
+        }
+
+        #endregion
+
+        #region CreateKeyEnumerableAsync
+        public Task<IAsyncEnumerable<TKey>> CreateKeyEnumerableAsync(ITransaction tx)
+        {
+            return CreateKeyEnumerableAsync(tx, EnumerationMode.Unordered, default(TimeSpan), CancellationToken.None);
+        }
+
+        public Task<IAsyncEnumerable<TKey>> CreateKeyEnumerableAsync(ITransaction tx, EnumerationMode enumerationMode)
+        {
+            return CreateKeyEnumerableAsync(tx, enumerationMode, default(TimeSpan), CancellationToken.None);
+        }
+
+        public async Task<IAsyncEnumerable<TKey>> CreateKeyEnumerableAsync(ITransaction tx, EnumerationMode enumerationMode, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            List<TKey> keys = new List<TKey>();
+
+            try
+            {
+                BeginTransaction(tx);
+                foreach (var key in Dictionary.Keys)
+                {
+                    await LockManager.AcquireLock(tx.TransactionId, key, LockMode.Default, timeout, cancellationToken);
+                    keys.Add(key);
+                }
+
+                if (enumerationMode == EnumerationMode.Ordered)
+                {
+                    keys.Sort();
+                }
+
+                IAsyncEnumerable<TKey> result = new MockAsyncEnumerable<TKey>(keys);
                 return result;
             }
             catch

--- a/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
+++ b/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
@@ -4,7 +4,7 @@
     <Description>ServiceFabric.Mocks contains many Mock and helper classes to facilitate and simplify unit testing of Service Fabric Actors and Services.</Description>
     <Copyright>2017</Copyright>
     <AssemblyTitle>ServiceFabric.Mocks</AssemblyTitle>
-    <VersionPrefix>3.1.1</VersionPrefix>
+    <VersionPrefix>3.1.2</VersionPrefix>
     <Authors>Loek Duys</Authors>
     <TargetFrameworks>net451;net46</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
@@ -22,6 +22,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <Platforms>x64</Platforms>
+    <Version>3.1.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release'">

--- a/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
+++ b/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
@@ -22,7 +22,6 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <Platforms>x64</Platforms>
-    <Version>3.1.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release'">

--- a/test/ServiceFabric.Mocks.Tests/MocksTests/MockReliableDictionaryTests.cs
+++ b/test/ServiceFabric.Mocks.Tests/MocksTests/MockReliableDictionaryTests.cs
@@ -39,6 +39,21 @@ namespace ServiceFabric.Mocks.Tests.MocksTests
         }
 
         [TestMethod]
+        public async Task DictionaryCountTest()
+        {
+            const string key = "key";
+            const string value = "value";
+
+            var dictionary = new MockReliableDictionary<string, string>(new Uri("fabric://MockReliableDictionary"));
+            var tx = new MockTransaction(null, 1);
+
+            await dictionary.AddAsync(tx, key, value);
+            var actual = dictionary.Count;
+
+            Assert.AreEqual(1, actual);
+        }
+
+        [TestMethod]
         public async Task DictionaryCreateKeyEnumerableAsyncTest()
         {
             const string key = "key";

--- a/test/ServiceFabric.Mocks.Tests/MocksTests/MockReliableDictionaryTests.cs
+++ b/test/ServiceFabric.Mocks.Tests/MocksTests/MockReliableDictionaryTests.cs
@@ -2,6 +2,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading.Tasks;
 using ServiceFabric.Mocks.ReliableCollections;
+using System.Threading;
 
 namespace ServiceFabric.Mocks.Tests.MocksTests
 {
@@ -35,6 +36,24 @@ namespace ServiceFabric.Mocks.Tests.MocksTests
             var actual = await dictionary.TryGetValueAsync(tx, key);
 
             Assert.AreEqual(actual.Value, value);
+        }
+
+        [TestMethod]
+        public async Task DictionaryCreateKeyEnumerableAsyncTest()
+        {
+            const string key = "key";
+            const string value = "value";
+
+            var dictionary = new MockReliableDictionary<string, string>(new Uri("fabric://MockReliableDictionary"));
+            var tx = new MockTransaction(null, 1);
+
+            await dictionary.AddAsync(tx, key, value);
+            var enumerable = await dictionary.CreateKeyEnumerableAsync(tx);
+            var enumerator = enumerable.GetAsyncEnumerator();
+            await enumerator.MoveNextAsync(CancellationToken.None);
+            var actual = enumerator.Current;
+
+            Assert.AreEqual(key, actual);
         }
     }
 }

--- a/test/ServiceFabric.Mocks.Tests/ServiceFabric.Mocks.Tests.csproj
+++ b/test/ServiceFabric.Mocks.Tests/ServiceFabric.Mocks.Tests.csproj
@@ -8,7 +8,7 @@
     <Description>ServiceFabric.Mocks contains Mock classes to enable unit testing of Actors and Services</Description>
     <Copyright>2017</Copyright>
     <AssemblyTitle>ServiceFabric.Mocks.Tests</AssemblyTitle>
-    <VersionPrefix>3.1.1</VersionPrefix>
+    <VersionPrefix>3.1.2</VersionPrefix>
     <Authors>Loek Duys</Authors>
     <TargetFrameworks>net451;net46</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>

--- a/test/ServiceFabric.Mocks.Tests/ServiceTests/MyStatefulServiceTests.cs
+++ b/test/ServiceFabric.Mocks.Tests/ServiceTests/MyStatefulServiceTests.cs
@@ -30,6 +30,24 @@ namespace ServiceFabric.Mocks.Tests.ServiceTests
             Assert.AreEqual(StatePayload, actual.Content);
         }
 
+        [TestMethod]
+        public async Task TestServiceState_Dictionary2()
+        {
+            var context = MockStatefulServiceContextFactory.Default;
+            var stateManager = new MockReliableStateManager();
+            var service = new MyStatefulService(context, stateManager);
+
+            const string stateName = "test";
+            var payload = new Payload(StatePayload);
+
+            //create state
+            await service.InsertAsync(stateName, payload);
+
+            //get state
+            var dictionary = await stateManager.TryGetAsync<IReliableDictionary2<string, Payload>>(MyStatefulService.StateManagerDictionaryKey);
+            var actual = (await dictionary.Value.TryGetValueAsync(stateManager.CreateTransaction(), stateName)).Value;
+            Assert.AreEqual(StatePayload, actual.Content);
+        }
 
         [TestMethod]
         public async Task TestServiceState_Queue()


### PR DESCRIPTION
This PR will fix the `InvalidCastException` caused when attempting to get `IReliableDictionary2` from the mock state manager.