### PR TITLE
Fix ArgumentException when creating IReliableDictionary2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The VSTS Agent lagged behind in Service Fabric SDK version, this caused runtime 
 
 ## Release notes
  - 3.1.3
-	- Fix creation of `IReliableDictionary2` collections
+	- Merged PR by Jaah. Fix creation of `IReliableDictionary2` collections
 
  - 3.1.2
 	- Merged PR by Jaah. Add support for `IReliableDictionary2`

--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ Or [donate](https://paypal.me/lduys/5) a cup of coffee.
 The VSTS Agent lagged behind in Service Fabric SDK version, this caused runtime errors. This issue is now resolved. 
 
 ## Release notes
- 3.1.2
+ - 3.1.3
+	- Fix creation of `IReliableDictionary2` collections
+
+ - 3.1.2
 	- Merged PR by Jaah. Add support for `IReliableDictionary2`
 
 - 3.1.1

--- a/src/ServiceFabric.Mocks/MockReliableStateManager.cs
+++ b/src/ServiceFabric.Mocks/MockReliableStateManager.cs
@@ -144,6 +144,10 @@
                 {
                     constructed = ConstructMockCollection(collectionName, typeof(MockReliableDictionary<,>), typeArguments);
                 }
+                else if (typeof(IReliableDictionary2<,>).IsAssignableFrom(typeDefinition))
+                {
+                    constructed = ConstructMockCollection(collectionName, typeof(MockReliableDictionary<,>), typeArguments);
+                }
                 else if (typeof(IReliableConcurrentQueue<>).IsAssignableFrom(typeDefinition))
                 {
                     constructed = ConstructMockCollection(collectionName, typeof(MockReliableConcurrentQueue<>), typeArguments);

--- a/src/ServiceFabric.Mocks/MockReliableStateManager.cs
+++ b/src/ServiceFabric.Mocks/MockReliableStateManager.cs
@@ -140,11 +140,8 @@
                 var typeArguments = typeof(T).GetGenericArguments();
                 var typeDefinition = typeof(T).GetGenericTypeDefinition();
 
-                if (typeof(IReliableDictionary<,>).IsAssignableFrom(typeDefinition))
-                {
-                    constructed = ConstructMockCollection(collectionName, typeof(MockReliableDictionary<,>), typeArguments);
-                }
-                else if (typeof(IReliableDictionary2<,>).IsAssignableFrom(typeDefinition))
+                if (typeof(IReliableDictionary<,>).IsAssignableFrom(typeDefinition)
+                || typeof(IReliableDictionary2<,>).IsAssignableFrom(typeDefinition))
                 {
                     constructed = ConstructMockCollection(collectionName, typeof(MockReliableDictionary<,>), typeArguments);
                 }

--- a/test/ServiceFabric.Mocks.Tests/MocksTests/MockReliableStateManagerTests.cs
+++ b/test/ServiceFabric.Mocks.Tests/MocksTests/MockReliableStateManagerTests.cs
@@ -1,0 +1,120 @@
+﻿using Microsoft.ServiceFabric.Data.Collections;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
+
+namespace ServiceFabric.Mocks.Tests.MocksTests
+{
+    [TestClass]
+    public class MockReliableStateManagerTests
+    {
+        [TestMethod]
+        public async Task GetOrAddAsync_Dictionary()
+        {
+            var collection = "GetOrAddAsync_Dictionary";
+            var sut = new MockReliableStateManager();
+
+            var actual = await sut.GetOrAddAsync<IReliableDictionary<string, string>>(collection);
+
+            Assert.IsNotNull(actual);
+        }
+
+        [TestMethod]
+        public async Task GetOrAddAsync_Dictionary2()
+        {
+            var collection = "GetOrAddAsync_Dictionary2";
+            var sut = new MockReliableStateManager();
+
+            var actual = await sut.GetOrAddAsync<IReliableDictionary2<string, string>>(collection);
+
+            Assert.IsNotNull(actual);
+        }
+
+        [TestMethod]
+        public async Task GetOrAddAsync_ConcurrentQueue()
+        {
+            var collection = "GetOrAddAsync_ConcurrentQueue";
+            var sut = new MockReliableStateManager();
+
+            var actual = await sut.GetOrAddAsync<IReliableConcurrentQueue<string>>(collection);
+
+            Assert.IsNotNull(actual);
+        }
+
+        [TestMethod]
+        public async Task GetOrAddAsync_Queue()
+        {
+            var collection = "GetOrAddAsync_Queue";
+            var sut = new MockReliableStateManager();
+
+            var actual = await sut.GetOrAddAsync<IReliableQueue<string>>(collection);
+
+            Assert.IsNotNull(actual);
+        }
+
+        [TestMethod]
+        public async Task TryGetAsync_Dictionary()
+        {
+            var collection = "TryGetAsync_Dictionary";
+            var sut = new MockReliableStateManager();
+
+            await sut.GetOrAddAsync<IReliableDictionary<string, string>>(collection);
+            var actual = await sut.TryGetAsync<IReliableDictionary<string, string>>(collection);
+
+            Assert.IsNotNull(actual);
+            Assert.IsTrue(actual.HasValue);
+        }
+
+        [TestMethod]
+        public async Task TryGetAsync_Dictionary2()
+        {
+            var collection = "TryGetAsync_Dictionary2";
+            var sut = new MockReliableStateManager();
+
+            await sut.GetOrAddAsync<IReliableDictionary2<string, string>>(collection);
+            var actual = await sut.TryGetAsync<IReliableDictionary2<string, string>>(collection);
+
+            Assert.IsNotNull(actual);
+            Assert.IsTrue(actual.HasValue);
+        }
+
+        [TestMethod]
+        public async Task TryGetAsync_ConcurrentQueue()
+        {
+            var collection = "TryGetAsync_ConcurrentQueue";
+            var sut = new MockReliableStateManager();
+
+            await sut.GetOrAddAsync<IReliableConcurrentQueue<string>>(collection);
+            var actual = await sut.TryGetAsync<IReliableConcurrentQueue<string>>(collection);
+
+            Assert.IsNotNull(actual);
+            Assert.IsTrue(actual.HasValue);
+        }
+
+        [TestMethod]
+        public async Task TryGetAsync_Queue()
+        {
+            var collection = "TryGetAsync_Queue";
+            var sut = new MockReliableStateManager();
+
+            await sut.GetOrAddAsync<IReliableQueue<string>>(collection);
+            var actual = await sut.TryGetAsync<IReliableQueue<string>>(collection);
+
+            Assert.IsNotNull(actual);
+            Assert.IsTrue(actual.HasValue);
+        }
+
+        [TestMethod]
+        public async Task RemoveAsync()
+        {
+            var collection = "RemoveAsync";
+            var sut = new MockReliableStateManager();
+
+            await sut.GetOrAddAsync<IReliableDictionary<string, string>>(collection);
+            await sut.RemoveAsync(collection);
+            var actual = await sut.TryGetAsync<IReliableDictionary<string, string>>(collection);
+
+            Assert.IsNotNull(actual);
+            Assert.IsFalse(actual.HasValue);
+        }
+    }
+}

--- a/test/ServiceFabric.Mocks.Tests/ServiceFabric.Mocks.Tests.csproj
+++ b/test/ServiceFabric.Mocks.Tests/ServiceFabric.Mocks.Tests.csproj
@@ -8,7 +8,7 @@
     <Description>ServiceFabric.Mocks contains Mock classes to enable unit testing of Actors and Services</Description>
     <Copyright>2017</Copyright>
     <AssemblyTitle>ServiceFabric.Mocks.Tests</AssemblyTitle>
-    <VersionPrefix>3.1.2</VersionPrefix>
+    <VersionPrefix>1.0.0</VersionPrefix>
     <Authors>Loek Duys</Authors>
     <TargetFrameworks>net451;net46</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>

--- a/test/ServiceFabric.Mocks.Tests/ServiceTests/MyStatefulServiceTests.cs
+++ b/test/ServiceFabric.Mocks.Tests/ServiceTests/MyStatefulServiceTests.cs
@@ -31,25 +31,6 @@ namespace ServiceFabric.Mocks.Tests.ServiceTests
         }
 
         [TestMethod]
-        public async Task TestServiceState_Dictionary2()
-        {
-            var context = MockStatefulServiceContextFactory.Default;
-            var stateManager = new MockReliableStateManager();
-            var service = new MyStatefulService(context, stateManager);
-
-            const string stateName = "test";
-            var payload = new Payload(StatePayload);
-
-            //create state
-            await service.InsertAsync(stateName, payload);
-
-            //get state
-            var dictionary = await stateManager.TryGetAsync<IReliableDictionary2<string, Payload>>(MyStatefulService.StateManagerDictionaryKey);
-            var actual = (await dictionary.Value.TryGetValueAsync(stateManager.CreateTransaction(), stateName)).Value;
-            Assert.AreEqual(StatePayload, actual.Content);
-        }
-
-        [TestMethod]
         public async Task TestServiceState_Queue()
         {
             var context = MockStatefulServiceContextFactory.Default;


### PR DESCRIPTION
This PR will:
- fix `ArgumentException` when trying to get or create  `IReliableDictionary2`
- add unit tests for `MockReliableStateManager`
- remove misleading `MyStatefulService` unit test for the feature

The previous PR did not fully implement the support for `IReliableDictionary2` (Apologies for that). The unit test in that was not testing `GetOrAddAsync` correctly. It only tested `TryGetAsync`, which would work because the `MyStatefulService.InsertAsync` creates the collection differently than expected.
