### PR TITLE
add support for missing actors with same ID but different types

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Thank you for contributing!
 The VSTS Agent lagged behind in Service Fabric SDK version, this caused runtime errors. This issue is now resolved. 
 
 ## Release notes
+
+  - 3.3.4
+     - Merged PR by Scythen. Fix for issue in MissingActor event using multiple Actor types with the same id.
+
   - 3.3.3
      - Upgraded to new SDK (SF 3.1.274).
 

--- a/src/ServiceFabric.Mocks/MockActorProxyFactory.cs
+++ b/src/ServiceFabric.Mocks/MockActorProxyFactory.cs
@@ -8,91 +8,95 @@ using System.Collections.Generic;
 
 namespace ServiceFabric.Mocks
 {
-	/// <summary>
-	/// Specifies the interface for the factory that creates proxies for remote communication to the specified Actor.
-	/// </summary>
-	public class MockActorProxyFactory : MockServiceProxyFactory, IActorProxyFactory
-	{
+    /// <summary>
+    /// Specifies the interface for the factory that creates proxies for remote communication to the specified Actor.
+    /// </summary>
+    public class MockActorProxyFactory : MockServiceProxyFactory, IActorProxyFactory
+    {
+        /// <summary>
+        /// Fires when an Actor is missing, set <see cref="MissingActorEventArgs.ActorInstance"/> to resolve.
+        /// </summary>
+        public event EventHandler<MissingActorEventArgs> MissingActor;
 
-		/// <summary>
-		/// Fires when an Actor is missing, set <see cref="MissingActorEventArgs.ActorInstance"/> to resolve.
-		/// </summary>
-		public event EventHandler<MissingActorEventArgs> MissingActor;
+        private readonly ConcurrentDictionary<ActorId, HashSet<IActor>> _actorRegistry = new ConcurrentDictionary<ActorId, HashSet<IActor>>();
 
-		private readonly ConcurrentDictionary<ActorId, HashSet<IActor>> _actorRegistry = new ConcurrentDictionary<ActorId, HashSet<IActor>>();
-		
-		/// <summary>
-		/// Registers an instance of a Actor combined with its Id to be able to return it from 
-		/// <see cref="CreateActorProxy{TActorInterface}(Microsoft.ServiceFabric.Actors.ActorId,string,string,string)"/>
-		/// </summary>
-		/// <param name="actor"></param>
-		public void RegisterActor(IActor actor)
-		{
-			_actorRegistry.AddOrUpdate(
-				actor.GetActorId(),
-				id => new HashSet<IActor>(new[] { actor }),
-				(id, set) =>
-				{
-					if (set.Any(a => a.GetType() == actor.GetType()))
-					{
-						throw new ArgumentException($"There is already an actor of type {actor.GetType()} with the actorId {id}.");
-					}
+        /// <summary>
+        /// Registers an instance of a Actor combined with its Id to be able to return it from 
+        /// <see cref="CreateActorProxy{TActorInterface}(Microsoft.ServiceFabric.Actors.ActorId,string,string,string)"/>
+        /// </summary>
+        /// <param name="actor"></param>
+        public void RegisterActor(IActor actor)
+        {
+            _actorRegistry.AddOrUpdate(
+                actor.GetActorId(),
+                id => new HashSet<IActor>(new[] { actor }),
+                (id, set) =>
+                {
+                    if (set.Any(a => a.GetType() == actor.GetType()))
+                    {
+                        throw new ArgumentException($"There is already an actor of type {actor.GetType()} with the actorId {id}.");
+                    }
 
-					set.Add(actor);
-					return set;
-				});
-		}
+                    set.Add(actor);
+                    return set;
+                });
+        }
 
-		///<inheritdoc />
-		public TActorInterface CreateActorProxy<TActorInterface>(ActorId actorId, string applicationName = null,
-			string serviceName = null, string listenerName = null) where TActorInterface : IActor
-		{
-			if (!_actorRegistry.ContainsKey(actorId))
-			{
-				OnMisingActor(this, actorId, typeof(TActorInterface));
-			}
+        ///<inheritdoc />
+        public TActorInterface CreateActorProxy<TActorInterface>(ActorId actorId, string applicationName = null,
+            string serviceName = null, string listenerName = null)
+            where TActorInterface : IActor
+        {
+            return CreateActorProxy<TActorInterface>(actorId);
+        }
 
-			var set = _actorRegistry[actorId];
-			return set.OfType<TActorInterface>().SingleOrDefault();
-		}
+        ///<inheritdoc />
+        public TActorInterface CreateActorProxy<TActorInterface>(Uri serviceUri, ActorId actorId, string listenerName = null)
+            where TActorInterface : IActor
+        {
+            return CreateActorProxy<TActorInterface>(actorId);
+        }
 
-		///<inheritdoc />
-		public TActorInterface CreateActorProxy<TActorInterface>(Uri serviceUri, ActorId actorId, string listenerName = null)
-			where TActorInterface : IActor
-		{
-			if (!_actorRegistry.ContainsKey(actorId))
-			{
-				OnMisingActor(this, actorId, typeof(TActorInterface));
-			}
+        ///<inheritdoc />
+        public TServiceInterface CreateActorServiceProxy<TServiceInterface>(Uri serviceUri, ActorId actorId, string listenerName = null)
+            where TServiceInterface : IService
+        {
+            var serviceInterface = CreateServiceProxy<TServiceInterface>(serviceUri);
+            return serviceInterface;
+        }
 
-			var set = _actorRegistry[actorId];
-			return set.OfType<TActorInterface>().SingleOrDefault();
-		}
+        ///<inheritdoc />
+        public TServiceInterface CreateActorServiceProxy<TServiceInterface>(Uri serviceUri, long partitionKey, string listenerName = null)
+            where TServiceInterface : IService
+        {
+            var serviceInterface = CreateServiceProxy<TServiceInterface>(serviceUri);
+            return serviceInterface;
+        }
 
-		///<inheritdoc />
-		public TServiceInterface CreateActorServiceProxy<TServiceInterface>(Uri serviceUri, ActorId actorId, string listenerName = null)
-			where TServiceInterface : IService
-		{
-			var serviceInterface = CreateServiceProxy<TServiceInterface>(serviceUri);
-			return serviceInterface;
-		}
+        protected virtual IActor OnMisingActor(object sender, ActorId id, Type actorType)
+        {
+            var args = new MissingActorEventArgs(actorType, id);
+            MissingActor?.Invoke(sender, args);
+            if (args.ActorInstance != null)
+            {
+                RegisterActor(args.ActorInstance);
+                return args.ActorInstance;
+            }
+            return null;
+        }
 
-		///<inheritdoc />
-		public TServiceInterface CreateActorServiceProxy<TServiceInterface>(Uri serviceUri, long partitionKey, string listenerName = null)
-			where TServiceInterface : IService
-		{
-			var serviceInterface = CreateServiceProxy<TServiceInterface>(serviceUri);
-			return serviceInterface;
-		}
+        protected TActorInterface CreateActorProxy<TActorInterface>(ActorId actorId)
+            where TActorInterface : IActor
+        {
+            if (!_actorRegistry.TryGetValue(actorId, out HashSet<IActor> set))
+                return (TActorInterface)OnMisingActor(this, actorId, typeof(TActorInterface));
 
-		protected virtual void OnMisingActor(object sender, ActorId id, Type actorType)
-		{
-			var args = new MissingActorEventArgs(actorType, id);
-			MissingActor?.Invoke(sender, args);
-			if (args.ActorInstance != null)
-			{
-				RegisterActor(args.ActorInstance);
-			}
-		}
-	}
+            var actor = set.OfType<TActorInterface>().SingleOrDefault();
+
+            if (actor != null)
+                return actor;
+
+            return (TActorInterface)OnMisingActor(this, actorId, typeof(TActorInterface));
+        }
+    }
 }

--- a/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
+++ b/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
@@ -4,7 +4,7 @@
     <Description>ServiceFabric.Mocks contains many Mock and helper classes to facilitate and simplify unit testing of Service Fabric Actors and Services.</Description>
     <Copyright>2018</Copyright>
     <AssemblyTitle>ServiceFabric.Mocks</AssemblyTitle>
-    <VersionPrefix>3.3.3</VersionPrefix>
+    <VersionPrefix>3.3.4</VersionPrefix>
     <Authors>Loek Duys</Authors>
     <TargetFrameworks>net452;net46;netstandard2.0</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>

--- a/test/ServiceFabric.Mocks.NetCoreTests/ServiceFabric.Mocks.NetCoreTests.csproj
+++ b/test/ServiceFabric.Mocks.NetCoreTests/ServiceFabric.Mocks.NetCoreTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>ServiceFabric.Mocks contains Mock classes to enable unit testing of Actors and Services</Description>
@@ -46,10 +46,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\ServiceFabric.Mocks\ServiceFabric.Mocks.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/test/ServiceFabric.Mocks.NetCoreTests/ServiceFabric.Mocks.NetCoreTests.csproj
+++ b/test/ServiceFabric.Mocks.NetCoreTests/ServiceFabric.Mocks.NetCoreTests.csproj
@@ -48,4 +48,8 @@
     <ProjectReference Include="..\..\src\ServiceFabric.Mocks\ServiceFabric.Mocks.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Proxy factory does not support having different type actors with the same ID when they are created by the MissingActor callback.

This change fixes that bug.