### PR TITLE
Let Lock try to acquire one last time after the wait time has expired…

### DIFF
--- a/src/ServiceFabric.Mocks/ReliableCollections/Lock.cs
+++ b/src/ServiceFabric.Mocks/ReliableCollections/Lock.cs
@@ -137,7 +137,10 @@
                 bool keepWaiting = await Wait(waitTimeMs, cancellationToken);
                 if (!keepWaiting)
                 {
-                    return AcquireResult.Denied;
+                    // One last attempt to reacquire the lock
+                    // in case it missed the signal that came
+                    // right before the last Wait.
+                    return TryAcquire(id, LockMode);
                 }
             }
             return AcquireResult.Denied;

--- a/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
+++ b/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
@@ -4,7 +4,7 @@
     <Description>ServiceFabric.Mocks contains many mocks and helper classes to facilitate and simplify unit testing of your Service Fabric Actor and Service projects.</Description>
     <Copyright>2018</Copyright>
     <AssemblyTitle>ServiceFabric.Mocks</AssemblyTitle>
-    <VersionPrefix>3.4.1</VersionPrefix>
+    <VersionPrefix>3.4.2</VersionPrefix>
     <Authors>Loek Duys</Authors>
     <TargetFrameworks>net452;net46;netstandard2.0</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>


### PR DESCRIPTION
… in case it misses the signal at prior to the last wait.

I believe the following scenario is still possible:
A and B both try to acquire lock.
A wins, B loses.
B goes through the loop of trying to acquire the lock and sleeping for 1/10th of the total wait time for a total of 9 times and still hasn't gotten the lock. 
B enters the loop again and if it fails to acquire the lock this time, it will go into it's final Wait() call unless it is woken up in the middle of that Wait().
B calls TryAcquire() for the 10th time and gets denied.
A finally releases the lock.
B calls Wait for the 10th time and has missed the signal from A so it will wait until the end. Wait() returns keepWaiting = False. 
B returns denied from Acquire

If B tries one last time to acquire the lock after it has exhausted all the time it was given to try then we know (in a 2 thread scenario) that it has to be the case that A still has lock and not that B missed the signal.

### Tests
I ran the ServiceFabric.Mocks.Test.TransactionTests several times and they all pass. Let me know if other tests should be ran as well. 

Relates to issue #70 