### PR TITLE
 3.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ The VSTS Agent lagged behind in Service Fabric SDK version, this caused runtime 
 
 ## Release notes
 
+   - 3.4.3 
+     - Minor fix; allow zero wait time for `ReliableConcurrentQueue` dequeue. Reported by CloudStu
+
    - 3.4.2 
      - Minor fix; add additional lock attempt. By likevi-MSFT
      

--- a/src/ServiceFabric.Mocks/ReliableCollections/Lock.cs
+++ b/src/ServiceFabric.Mocks/ReliableCollections/Lock.cs
@@ -128,7 +128,7 @@
             DateTime stopAfter = DateTime.UtcNow.AddMilliseconds(milliseconds);
             int waitTimeMs = (int)milliseconds / 10; //timer resolution of 1/10 wait time
 
-            while (DateTime.UtcNow < stopAfter)
+            do
             {
                 var result = TryAcquire(id, lockMode);
                 if (result != AcquireResult.Denied)
@@ -142,7 +142,8 @@
                     // right before the last Wait.
                     return TryAcquire(id, LockMode);
                 }
-            }
+            } while (DateTime.UtcNow < stopAfter);
+
             return AcquireResult.Denied;
 
         }

--- a/src/ServiceFabric.Mocks/ReliableCollections/MockReliableConcurrentQueue.cs
+++ b/src/ServiceFabric.Mocks/ReliableCollections/MockReliableConcurrentQueue.cs
@@ -66,7 +66,7 @@
         }
 
         /// <summary>
-        /// Try to dequeue the next available item in the queue. Try to wait specified timtout if the queue is empty.
+        /// Try to dequeue the next available item in the queue. Try to wait specified timeout if the queue is empty.
         /// </summary>
         /// <param name="tx">Transaction</param>
         /// <param name="cancellationToken">Cancellation Token</param>
@@ -81,7 +81,7 @@
             sw.Start();
 
             // Try to get committed item from the queue
-            for (long milliseconds = totalMilliseconds; milliseconds > 0; milliseconds = totalMilliseconds - sw.ElapsedMilliseconds)
+            for (long milliseconds = totalMilliseconds; milliseconds >= 0; milliseconds = totalMilliseconds - sw.ElapsedMilliseconds)
             {
                 if (AcquireResult.Denied != await _queueEmptyLock.Acquire(tx.TransactionId, LockMode.Default, milliseconds, cancellationToken))
                 {

--- a/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
+++ b/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
@@ -4,7 +4,7 @@
     <Description>ServiceFabric.Mocks contains many mocks and helper classes to facilitate and simplify unit testing of your Service Fabric Actor and Service projects.</Description>
     <Copyright>2018</Copyright>
     <AssemblyTitle>ServiceFabric.Mocks</AssemblyTitle>
-    <VersionPrefix>3.4.2</VersionPrefix>
+    <VersionPrefix>3.4.3</VersionPrefix>
     <Authors>Loek Duys</Authors>
     <TargetFrameworks>net452;net46;netstandard2.0</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>

--- a/test/ServiceFabric.Mocks.Tests/MocksTests/MockReliableConcurrentQueueTests.cs
+++ b/test/ServiceFabric.Mocks.Tests/MocksTests/MockReliableConcurrentQueueTests.cs
@@ -34,6 +34,21 @@
         }
 
         [TestMethod]
+        public async Task DequeueWithZeroTimeoutTest()
+        {
+            var q = new MockReliableConcurrentQueue<int>(new Uri("test://queue"));
+            using (var tx = _stateManager.CreateTransaction())
+            {
+                await q.EnqueueAsync(tx, 1);
+                await tx.CommitAsync();
+            
+                var result = await q.TryDequeueAsync(tx, timeout: TimeSpan.FromMilliseconds(0));
+                Assert.IsTrue(result.HasValue);
+                Assert.AreEqual(1, result.Value);
+            }
+        }
+
+        [TestMethod]
         public async Task DequeueOtherEnqueueTest()
         {
             var q = new MockReliableConcurrentQueue<int>(new Uri("test://queue"));


### PR DESCRIPTION
     - Minor fix; allow zero wait time for `ReliableConcurrentQueue` dequeue. Reported by CloudStu