### PR TITLE
Upgraded to new SDK (SF 3.3.624)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ The VSTS Agent lagged behind in Service Fabric SDK version, this caused runtime 
 
 ## Release notes
 
+   - 3.4.4
+     - Upgraded to new SDK (SF 3.3.624).
+
    - 3.4.3 
      - Minor fix; allow zero wait time for `ReliableConcurrentQueue` dequeue. Reported by CloudStu
 

--- a/src/ServiceFabric.Mocks/MockServiceProxyFactory.cs
+++ b/src/ServiceFabric.Mocks/MockServiceProxyFactory.cs
@@ -24,6 +24,13 @@ namespace ServiceFabric.Mocks
 
         }
 
+        /// <inheritdoc />
+        public TServiceInterface CreateNonIServiceProxy<TServiceInterface>(Uri serviceUri, ServicePartitionKey partitionKey = null, TargetReplicaSelector targetReplicaSelector = TargetReplicaSelector.Default, string listenerName = null)
+        {
+            // TODO: Introduce MockServiceProxyForNonServiceInterface
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// Registers an instance of a service combined with its name to be able to return it from <see cref="CreateServiceProxy{TServiceInterface}"/>
         /// </summary>

--- a/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
+++ b/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
@@ -4,7 +4,7 @@
     <Description>ServiceFabric.Mocks contains many mocks and helper classes to facilitate and simplify unit testing of your Service Fabric Actor and Service projects.</Description>
     <Copyright>2018</Copyright>
     <AssemblyTitle>ServiceFabric.Mocks</AssemblyTitle>
-    <VersionPrefix>3.4.3</VersionPrefix>
+    <VersionPrefix>3.4.4</VersionPrefix>
     <Authors>Loek Duys</Authors>
     <TargetFrameworks>net452;net46;netstandard2.0</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
@@ -38,11 +38,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ServiceFabric" Version="6.3.187" />
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.2.187" />
-    <PackageReference Include="Microsoft.ServiceFabric.Data" Version="3.2.187" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="3.2.187" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="3.2.187" />
+    <PackageReference Include="Microsoft.ServiceFabric" Version="6.4.624" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.3.624" />
+    <PackageReference Include="Microsoft.ServiceFabric.Data" Version="3.3.624" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="3.3.624" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="3.3.624" />
   </ItemGroup>
 
 </Project>

--- a/test/ServiceFabric.Mocks.NetCoreTests/ServiceFabric.Mocks.NetCoreTests.csproj
+++ b/test/ServiceFabric.Mocks.NetCoreTests/ServiceFabric.Mocks.NetCoreTests.csproj
@@ -35,13 +35,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.2.187" />
-    <PackageReference Include="Microsoft.ServiceFabric.Data" Version="3.2.187" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="3.2.187" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="3.2.187" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.3.624" />
+    <PackageReference Include="Microsoft.ServiceFabric.Data" Version="3.3.624" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="3.3.624" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="3.3.624" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/ServiceFabric.Mocks.Tests/ServiceFabric.Mocks.Tests.csproj
+++ b/test/ServiceFabric.Mocks.Tests/ServiceFabric.Mocks.Tests.csproj
@@ -32,14 +32,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Microsoft.ServiceFabric" Version="6.3.187" />
-    <PackageReference Include="Microsoft.ServiceFabric.Data" Version="3.2.187" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="3.2.187" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.2.187" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="3.2.187" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.ServiceFabric" Version="6.4.624" />
+    <PackageReference Include="Microsoft.ServiceFabric.Data" Version="3.3.624" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="3.3.624" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.3.624" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="3.3.624" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
SF version update.

Not sure what to do with: CreateNonIServiceProxy. I believe we have to change the MockServiceProxy.
I don't use this method yet, but I do need the new SF version in order to update my projects.
Hopefully you can accept the pull request as it is now.