### PR TITLE
upgraded to new SDK (SF 3.4.658)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Thank you for contributing!
 
 ## Release notes
 
+- 3.4.17
+    - upgraded to new SDK (SF 3.4.658)
+
 - 3.4.16
     - upgraded to new SDK (SF 3.4.641)
 

--- a/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
+++ b/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
@@ -4,7 +4,7 @@
     <Description>ServiceFabric.Mocks contains many mocks and helper classes to facilitate and simplify unit testing of your Service Fabric Actor and Service projects.</Description>
     <Copyright>2019</Copyright>
     <AssemblyTitle>ServiceFabric.Mocks</AssemblyTitle>
-    <Version>3.4.16</Version>
+    <Version>3.4.17</Version>
     <Authors>Loek Duys</Authors>
     <TargetFrameworks>net452;net46;netstandard2.0</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
@@ -38,11 +38,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ServiceFabric" Version="6.5.641" />
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.4.641" />
-    <PackageReference Include="Microsoft.ServiceFabric.Data" Version="3.4.641" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="3.4.641" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="3.4.641" />
+    <PackageReference Include="Microsoft.ServiceFabric" Version="6.5.658" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.4.658" />
+    <PackageReference Include="Microsoft.ServiceFabric.Data" Version="3.4.658" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="3.4.658" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="3.4.658" />
   </ItemGroup>
 
 </Project>

--- a/test/ServiceFabric.Mocks.NetCoreTests/ServiceFabric.Mocks.NetCoreTests.csproj
+++ b/test/ServiceFabric.Mocks.NetCoreTests/ServiceFabric.Mocks.NetCoreTests.csproj
@@ -35,10 +35,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.4.641" />
-    <PackageReference Include="Microsoft.ServiceFabric.Data" Version="3.4.641" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="3.4.641" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="3.4.641" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.4.658" />
+    <PackageReference Include="Microsoft.ServiceFabric.Data" Version="3.4.658" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="3.4.658" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="3.4.658" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />

--- a/test/ServiceFabric.Mocks.Tests/ServiceFabric.Mocks.Tests.csproj
+++ b/test/ServiceFabric.Mocks.Tests/ServiceFabric.Mocks.Tests.csproj
@@ -33,13 +33,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Microsoft.ServiceFabric" Version="6.5.641" />
-    <PackageReference Include="Microsoft.ServiceFabric.Data" Version="3.4.641" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="3.4.641" />
+    <PackageReference Include="Microsoft.ServiceFabric" Version="6.5.658" />
+    <PackageReference Include="Microsoft.ServiceFabric.Data" Version="3.4.658" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="3.4.658" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.4.641" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="3.4.641" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.4.658" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="3.4.658" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Sorry for any confusion caused by my initial commit message typo. To be extra clear, this PR is upgrading the SF framework references to v3.4.658.