### PR TITLE
init data propagation and fqdn change

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Or [donate](https://paypal.me/lduys/5) a cup of coffee.
 Thank you for contributing!
 
 ## Release notes
+- 3.4.19
+	- minor change; added InitializationData being passed to service context via context factory/replica set
 
 - 3.4.18
     - upgraded to new SDK (SF 3.4.664)

--- a/src/ServiceFabric.Mocks/MockStatefulServiceContext.cs
+++ b/src/ServiceFabric.Mocks/MockStatefulServiceContext.cs
@@ -29,15 +29,16 @@ namespace ServiceFabric.Mocks
 		/// <param name="serviceName">The URI that should be used by the ServiceContext</param>
 		/// <param name="partitionId">PartitionId</param>
 		/// <param name="replicaId">ReplicaId</param>
+		/// <param name="initializationData">initialization data</param>
 		/// <returns>The constructed <see cref="StatefulServiceContext"/></returns>
-		public static StatefulServiceContext Create(ICodePackageActivationContext codePackageActivationContext, string serviceTypeName, Uri serviceName, Guid partitionId, long replicaId)
+		public static StatefulServiceContext Create(ICodePackageActivationContext codePackageActivationContext, string serviceTypeName, Uri serviceName, Guid partitionId, long replicaId, byte[] initializationData=null)
         {
             return new StatefulServiceContext(
-               new NodeContext("Node0", new NodeId(0, 1), 0, "NodeType1", "MOCK.MACHINE"),
+               new NodeContext("Node0", new NodeId(0, 1), 0, "NodeType1", "localhost"),
                codePackageActivationContext, 
 			   serviceTypeName,
                serviceName,
-               null,
+               initializationData,
                partitionId,
                replicaId
             );

--- a/src/ServiceFabric.Mocks/MockStatelessServiceContextFactory.cs
+++ b/src/ServiceFabric.Mocks/MockStatelessServiceContextFactory.cs
@@ -30,19 +30,20 @@ namespace ServiceFabric.Mocks
 		/// <param name="serviceName">The URI that should be used by the ServiceContext</param>
 		/// <param name="partitionId">PartitionId</param>
 		/// <param name="instanceId">InstanceId</param>
+		/// <param name="initializationData">initialization data</param>
 		/// </summary>
 		public static StatelessServiceContext Create(ICodePackageActivationContext codePackageActivationContext, 
 			string serviceTypeName, 
 			Uri serviceName,
 			Guid partitionId, 
-			long instanceId)
+			long instanceId, byte[] initializationData=null)
 		{
 			return new StatelessServiceContext(
-				new NodeContext("Node0", new NodeId(0, 1), 0, "NodeType1", "MOCK.MACHINE"),
+				new NodeContext("Node0", new NodeId(0, 1), 0, "NodeType1", "localhost"),
 				codePackageActivationContext, 
 				serviceTypeName,
 				serviceName,
-				null,
+				initializationData,
 				partitionId,
 				instanceId);
 		}

--- a/src/ServiceFabric.Mocks/ReplicaSet/MockStatefulServiceReplicaSet.cs
+++ b/src/ServiceFabric.Mocks/ReplicaSet/MockStatefulServiceReplicaSet.cs
@@ -77,9 +77,9 @@ namespace ServiceFabric.Mocks.ReplicaSet
 
         public MockStatefulServiceReplica<TStatefulService> GetDeleted(long? replicaId = null) => replicaId.HasValue ? DeletedReplicas.SingleOrDefault(r => r.ReplicaId == replicaId) : FirstDeleted;
 
-        public async Task AddReplicaAsync(ReplicaRole role, long? replicaId = null, int activationDelayMs = 0)
+        public async Task AddReplicaAsync(ReplicaRole role, long? replicaId = null, int activationDelayMs = 0, byte[] initializationData=null)
         {
-            var serviceContext = MockStatefulServiceContextFactory.Create(CodePackageActivationContext, ServiceTypeName, ServiceUri, Guid.NewGuid(), replicaId ?? _random.Next());
+            var serviceContext = MockStatefulServiceContextFactory.Create(CodePackageActivationContext, ServiceTypeName, ServiceUri, Guid.NewGuid(), replicaId ?? _random.Next(), initializationData);
             var stateManager = _stateManagerFactory(serviceContext, _reliableStates);
             var replica = new MockStatefulServiceReplica<TStatefulService>(_serviceFactory, serviceContext, stateManager);
             await replica.CreateAsync(role);

--- a/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
+++ b/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
@@ -4,7 +4,7 @@
     <Description>ServiceFabric.Mocks contains many mocks and helper classes to facilitate and simplify unit testing of your Service Fabric Actor and Service projects.</Description>
     <Copyright>2019</Copyright>
     <AssemblyTitle>ServiceFabric.Mocks</AssemblyTitle>
-    <Version>3.4.18</Version>
+    <Version>3.4.19</Version>
     <Authors>Loek Duys</Authors>
     <TargetFrameworks>net452;net46;netstandard2.0</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>

--- a/test/ServiceFabric.Mocks.Tests/MocksTests/MockStatefulServiceContextFactoryTests.cs
+++ b/test/ServiceFabric.Mocks.Tests/MocksTests/MockStatefulServiceContextFactoryTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Fabric;
+using System.Text;
 using ServiceFabric.Mocks.Tests.Services;
 
 namespace ServiceFabric.Mocks.Tests.MocksTests
@@ -36,6 +37,27 @@ namespace ServiceFabric.Mocks.Tests.MocksTests
             Assert.AreEqual(partitionId, instance.PartitionId);
             Assert.AreEqual(replicaId, instance.ReplicaId);
             Assert.AreEqual(replicaId, instance.ReplicaOrInstanceId);
+        }
+
+        [TestMethod]
+        public void TestCustom_WithInitData()
+        {
+            var newUri = new Uri("fabric:/MockApp/OtherMockStatefulService");
+            var serviceTypeName = "OtherMockServiceType";
+            var partitionId = Guid.NewGuid();
+            var replicaId = long.MaxValue;
+            var context = new MockCodePackageActivationContext("fabric:/MyApp", "MyAppType", "Code", "Ver", "Context", "Log", "Temp", "Work", "Man", "ManVer");
+
+            var instance = MockStatefulServiceContextFactory.Create(context, serviceTypeName, newUri, partitionId, replicaId, Encoding.UTF8.GetBytes("blah"));
+
+            Assert.IsInstanceOfType(instance, typeof(StatefulServiceContext));
+            Assert.AreEqual(context, instance.CodePackageActivationContext);
+            Assert.AreEqual(newUri, instance.ServiceName);
+            Assert.AreEqual(serviceTypeName, instance.ServiceTypeName);
+            Assert.AreEqual(partitionId, instance.PartitionId);
+            Assert.AreEqual(replicaId, instance.ReplicaId);
+            Assert.AreEqual(replicaId, instance.ReplicaOrInstanceId);
+            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("blah"), instance.InitializationData);
         }
     }
 }

--- a/test/ServiceFabric.Mocks.Tests/MocksTests/MockStatelessServiceContextFactoryTests.cs
+++ b/test/ServiceFabric.Mocks.Tests/MocksTests/MockStatelessServiceContextFactoryTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Fabric;
+using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ServiceFabric.Mocks.Tests.MocksTests
@@ -36,5 +37,26 @@ namespace ServiceFabric.Mocks.Tests.MocksTests
 			Assert.AreEqual(replicaId, instance.InstanceId);
 			Assert.AreEqual(replicaId, instance.ReplicaOrInstanceId);
 		}
-	}
+
+        [TestMethod]
+        public void TestCustom_WithInitData()
+        {
+            var newUri = new Uri("fabric:/MockApp/OtherMockStatelessService");
+            var serviceTypeName = "OtherMockServiceType";
+            var partitionId = Guid.NewGuid();
+            var replicaId = long.MaxValue;
+            var context = new MockCodePackageActivationContext("fabric:/MyApp", "MyAppType", "Code", "Ver", "Context", "Log", "Temp", "Work", "Man", "ManVer");
+
+            var instance = MockStatelessServiceContextFactory.Create(context, serviceTypeName, newUri, partitionId, replicaId, Encoding.UTF8.GetBytes("blah"));
+
+            Assert.IsInstanceOfType(instance, typeof(StatelessServiceContext));
+            Assert.AreEqual(context, instance.CodePackageActivationContext);
+            Assert.AreEqual(newUri, instance.ServiceName);
+            Assert.AreEqual(serviceTypeName, instance.ServiceTypeName);
+            Assert.AreEqual(partitionId, instance.PartitionId);
+            Assert.AreEqual(replicaId, instance.InstanceId);
+            Assert.AreEqual(replicaId, instance.ReplicaOrInstanceId);
+            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("blah"), instance.InitializationData);
+        }
+    }
 }


### PR DESCRIPTION
@loekd I created this PR in draft state to socialise it with you and would like to hear your feedback re this, especially the fqdn part

two changes here

fqdn - with the hostname you have there I am getting COM issue - I assume you have some host name setup locally?

initialization data for SF context - we use this in the very vanilla sense.. in our event driven architecture app, our "director" service creates other services instance per event type and the type for the instance is passed via initialization data

we currently support this by creating a separate (inheriting from your one) context factory but given the nature of the flow here, it seems like generic enough feature

using your context factory would a) simplify the test code and b) it simplifies handling of replica id as it enables it to be passed when adding replicas(whereas if I create my own context I have to set it up there and the replica param of addreplica calls would be ignored)

looking forward to your input/thoughs and if you agree with the approach, I would add tests etc. to make this into full PR