### PR TITLE
Implement LastException to include the exception thrown from RunAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Thank you for contributing!
 
 ## Release notes
 
+- 5.0.7
+    - Implement LastException to include the exception thrown from RunAsync
+
 - 5.0.6
     - Update Service Fabric SDK to version 5.2.1363
     - Fix issue #120 reported by gtcooke94. Notification for reliable dictionary clearing.

--- a/src/ServiceFabric.Mocks/ReplicaSet/MockStatefulServiceReplica.cs
+++ b/src/ServiceFabric.Mocks/ReplicaSet/MockStatefulServiceReplica.cs
@@ -29,7 +29,15 @@ namespace ServiceFabric.Mocks.ReplicaSet
 
         public TStatefulService ServiceInstance => _serviceInstance;
 
-        public Exception LastException { get; set; }
+        public Exception LastException {
+            get {
+                if (_runAsyncTask != null && _runAsyncTask.IsFaulted)
+                {
+                    return _runAsyncTask.Exception;
+                }
+                return null;
+            }
+        }
 
         public CancellationTokenSource RunCancellation { get; set; } = new CancellationTokenSource();
 

--- a/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
+++ b/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
@@ -4,7 +4,7 @@
     <Description>ServiceFabric.Mocks contains many mocks and helper classes to facilitate and simplify unit testing of your Service Fabric Actor and Service projects.</Description>
     <Copyright>2022</Copyright>
     <AssemblyTitle>ServiceFabric.Mocks</AssemblyTitle>
-    <Version>5.0.6</Version>
+    <Version>5.0.7</Version>
     <Authors>Loek Duys</Authors>
     <TargetFrameworks>net452;net48;netstandard2.0</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>


### PR DESCRIPTION
LastException property will return the _runAsyncTask exception if it has faulted