### PR TITLE
Updated MSTest.* from 3.7.3 to 3.8.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,8 +13,8 @@
   <!-- ServiceFabric.Mocks.NetCoreTests.csproj -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.7.3" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.7.3" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.8.0" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.8.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Supersedes #238, #239 as both packages needs to be updated simultaneously.