### PR TITLE
Update Service Fabric SDK download link

### DIFF
--- a/.github/workflows/NuGetCD.yml
+++ b/.github/workflows/NuGetCD.yml
@@ -112,7 +112,7 @@ jobs:
             Write-Output "Registry key not found: $keyPath"
           }
         
-        Invoke-RestMethod -OutFile setup.exe -Method GET -Uri https://download.microsoft.com/download/b/8/a/b8a2fb98-0ec1-41e5-be98-9d8b5abf7856/MicrosoftServiceFabric.11.4.268.1.exe
+        Invoke-RestMethod -OutFile setup.exe -Method GET -Uri https://download.microsoft.com/download/b/8/a/b8a2fb98-0ec1-41e5-be98-9d8b5abf7856/MicrosoftServiceFabric.11.5.111.1.exe
         #.\setup.exe  /accepteula /force /quiet
         Start-Process setup.exe -UseNewEnvironment -ArgumentList '/accepteula /force /quiet' -Wait
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
             Write-Output "Registry key not found: $keyPath"
           }
           # see https://learn.microsoft.com/en-us/azure/service-fabric/service-fabric-get-started
-          Invoke-RestMethod -OutFile setup.exe -Method GET -Uri https://download.microsoft.com/download/b/8/a/b8a2fb98-0ec1-41e5-be98-9d8b5abf7856/MicrosoftServiceFabric.11.4.268.1.exe
+          Invoke-RestMethod -OutFile setup.exe -Method GET -Uri https://download.microsoft.com/download/b/8/a/b8a2fb98-0ec1-41e5-be98-9d8b5abf7856/MicrosoftServiceFabric.11.5.111.1.exe
           # .\setup.exe  /accepteula /force /quiet
           Start-Process setup.exe -UseNewEnvironment -ArgumentList '/accepteula /force /quiet' -Wait
      


### PR DESCRIPTION
This PR updates the Service Fabric SDK download link to the latest version: https://download.microsoft.com/download/b/8/a/b8a2fb98-0ec1-41e5-be98-9d8b5abf7856/MicrosoftServiceFabric.11.5.111.1.exe